### PR TITLE
Fallback to .config/please/plzconfig and...

### DIFF
--- a/pleasew
+++ b/pleasew
@@ -8,7 +8,7 @@ RESET="\x1B[0m"
 
 DEFAULT_URL_BASE="https://get.please.build"
 # We might already have it downloaded...
-LOCATION=$(grep -i "^location" .plzconfig 2>/dev/null | cut -d '=' -f 2 | tr -d ' ')
+LOCATION=$(grep -i "^location" ".plzconfig" "$HOME/.config/please/plzconfig" 2>/dev/null | head -n 1 | cut -d '=' -f 2 | tr -d ' ')
 if [ -z "$LOCATION" ]; then
     if [ -z "$HOME" ]; then
         echo -e >&2 "${RED}\$HOME not set, not sure where to look for Please.${RESET}"
@@ -18,6 +18,8 @@ if [ -z "$LOCATION" ]; then
 else
     # It can contain a literal ~, need to explicitly handle that.
     LOCATION="${LOCATION/\~/$HOME}"
+    # It can contain a literal $USER, need to explicitly handle that.
+    LOCATION="${LOCATION/\$USER/$USER}"
 fi
 # If this exists at any version, let it handle any update.
 TARGET="${LOCATION}/please"


### PR DESCRIPTION
allow $USER in the location config.

This will allow the please binary to be stored in a location other than the home directory `~/.please/`.